### PR TITLE
added comments and removed dotenv dependency

### DIFF
--- a/NPM Package/svelvetcake/Containers/GraphView/index.svelte
+++ b/NPM Package/svelvetcake/Containers/GraphView/index.svelte
@@ -72,8 +72,9 @@ function handleZoom(e) {
     {#each $nodesStore as node}
       {#if node.image && !node.data.label}
         <ImageNode {node} {key} />
+        <!-- If node has html property:  -->
       {:else if node.data.html}
-        <Node {node} {key}>{@html node.data.html}</Node>
+        <Node {node} {key}>{@html node.data.html}</Node> <!-- Directly render HTML inside of Node Component  -->
       {:else}
         <Node {node} {key}>{node.data.label}</Node>
       {/if}

--- a/NPM Package/svelvetcake/Nodes/index.svelte
+++ b/NPM Package/svelvetcake/Nodes/index.svelte
@@ -64,6 +64,7 @@
     $nodeSelected = true;
   }}
   on:mouseup={(e) => {
+    // If user sets snap attribute as true inside Svelvet 
     if ($snapgrid) {
       node.position.x = Math.floor(node.position.x / 30) * 30;
       node.position.y = Math.floor(node.position.y / 30) * 30;

--- a/NPM Package/svelvetcake/README.md
+++ b/NPM Package/svelvetcake/README.md
@@ -13,6 +13,12 @@ v 1.1.1
 
 v 1.1.2
 - added changes to svelvetcake -> Containers -> Graphview -> index.svelte
-- now, in nodes declaration, user has option to add data: { html : `<p> HTML DATA HERE </p>`}
+- now, in nodes declaration, user has option to add data: { html : \`  HTML DATA HERE `}; html value should be enclosed in template literals
 - resolved github issue #112, added HTML data enhancement
 - special thanks to ronvoluted (Ron Au) for contributing this feature
+
+v 1.1.3
+ - added comments demarcating & explaining Snap-to-Grid functionality & HTML data option
+ - removed dotenv as a dependency from package.json (unused library that takes up ~40 mb after npm install)
+ - have previously removed node.env dependency upon creation of svelvetcake
+ - removal of both these dependencies from package.json of NPM Package resolves Github Issue # 118

--- a/NPM Package/svelvetcake/package.json
+++ b/NPM Package/svelvetcake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelvetcake",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "custom svelvet NPM fork to make adding  changes to NPM Package simpler",
   "keywords": [
     "svelte",
@@ -56,7 +56,6 @@
     "acorn": "^8.7.1",
     "codemirror": "^5.65.6",
     "d3-zoom": "^3.0.0",
-    "dotenv": "^16.0.1",
     "estree-walker": "^3.0.1",
     "marked": "^4.0.17",
     "svelte-json-tree": "^1.0.0",


### PR DESCRIPTION
already npm published svelvetcake v1.1.3 only after testing to ensure no breaking changes with a separate npm package (haterade123)


just removing the dotenv dependency from inside package.json of NPM package reduced the overall size of a degit svelte app from ~101MB to  roughly 40MB